### PR TITLE
Fix typo in using_ssh_key variable.

### DIFF
--- a/manifests/sftp/user.pp
+++ b/manifests/sftp/user.pp
@@ -122,7 +122,7 @@ define ssh::sftp::user (
     }
   }
 
-  if $using_ssk_key {
+  if $using_ssh_key {
     file {"${user_home}/.ssh":
       ensure => directory,
       mode   => '0700',


### PR DESCRIPTION
Currently ssh key deployment is not working due to a typo.
